### PR TITLE
Prepare for 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Work in progress manager for systemd system extensions (sysexts).
 Install the `sysexts-manager` pre-built sysext:
 
 ```
-$ VERSION="0.0.1" # sysexts-manager version
+$ VERSION="0.2.0" # sysexts-manager version
 $ VERSION_ID="42" # Fedora release
 $ ARCH="x86-64"   # or arm64
 $ URL="https://github.com/travier/sysexts-manager/releases/download/sysexts-manager/"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ sysexts-manager status
 Install the tree sysext from [extensions.fcos.fr](https://extensions.fcos.fr):
 
 ```
-$ sudo sysexts-manager add tree https://extensions.fcos.fr/extensions/tree
+$ sudo sysexts-manager add tree https://extensions.fcos.fr/extensions
 ```
 
 Update all sysexts managed by sysexts-manager:
@@ -70,6 +70,36 @@ We statically install a copy of the `sysexts-manager` sysext and enable
 `systemd-sysext.service` to run on boot. When systemd loads the
 `sysexts-manager` sysext on boot, it will trigger `sysexts-manager.service`
 which will enable and load all other sysexts on demand.
+
+## Expected layout for hosted sysexts
+
+sysexts-manager expects to find the following layout at the URL used to
+setup a sysext. This layout is intended to match the one defiend in
+[systemd's sysupdate.d](https://www.freedesktop.org/software/systemd/man/latest/sysupdate.d.html).
+Any deviations will be considered a bug.
+
+For the systext `tree`, with the URL configured to
+`https://extensions.fcos.fr/extensions`, sysexts-manager will expect:
+
+```
+.
+└── tree
+    ├── SHA256SUMS
+    ├── tree-2.1.0-6.fc41-41-arm64.raw
+    ├── tree-2.1.0-6.fc41-41-x86-64.raw
+    ├── tree-2.2.1-1.fc42-42-arm64.raw
+    └── tree-2.2.1-1.fc42-42-x86-64.raw
+```
+
+It will thus fetch `https://extensions.fcos.fr/extensions/tree/SHA256SUMS`
+first to get the list of available versions, and then will fetch updates as
+needed.
+
+You can host your own sysexts anywhere that offers access over HTTPS. See the
+[actions](.github/actions) in this repo for an example to build and host your
+own using GitHub releases. See
+[issue#10](https://github.com/travier/sysexts-manager/issues/10) if you are
+interested in turning this into an independent GitHub Action.
 
 ## Why?
 

--- a/justfile
+++ b/justfile
@@ -1,5 +1,8 @@
 all: build-run
 
+lint:
+    cargo fmt && cargo build && cargo clippy
+
 # Direct run, i.e. like cargo run
 build-run *args:
     cargo build

--- a/lib/src/manager.rs
+++ b/lib/src/manager.rs
@@ -89,7 +89,6 @@ impl<W: Write> Write for Sha256Writer<W> {
     }
 }
 
-#[allow(dead_code)]
 pub fn new() -> Result<Manager> {
     // let dir = cap_std::open_ambient_dir("/")?;
     // new_with_root(Path::new(dir))
@@ -375,7 +374,7 @@ impl Manager {
 
         // TODO: Add config to manager
 
-        println!("Successfully added configuration for sysext: {name}");
+        println!("Added configuration for sysext: {name} ({url})");
 
         Ok(())
     }
@@ -437,7 +436,7 @@ impl Manager {
             }
         }
 
-        println!("Successfully removed configuration and images for sysext: {name}");
+        println!("Removed configuration and images for sysext: {name}");
 
         Ok(())
     }

--- a/lib/src/manager.rs
+++ b/lib/src/manager.rs
@@ -446,11 +446,10 @@ impl Manager {
             "Downloading SHA256SUMS for: {} (version_id: {}, arch: {})",
             config.Name, self.system.version_id, self.system.arch
         );
+        let sha256sum_url = format!("{}/{}/SHA256SUMS", config.Url, config.Name);
+        debug!("Downloading: {sha256sum_url}");
         let client = reqwest::blocking::Client::new();
-        let sha256sums = client
-            .get(format!("{}/SHA256SUMS", config.Url))
-            .send()?
-            .text()?;
+        let sha256sums = client.get(sha256sum_url).send()?.text()?;
         debug!("{sha256sums}");
 
         // Parse images and hashes list from SHA256SUM file
@@ -543,10 +542,9 @@ impl Manager {
         };
 
         println!("Downloading update: {}", download_image.path());
-        debug!("Downloading: {}/{}", config.Url, download_image.path());
-        let mut response = client
-            .get(format!("{}/{}", config.Url, download_image.path()))
-            .send()?;
+        let image_url = format!("{}/{}/{}", config.Url, config.Name, download_image.path());
+        debug!("Downloading: {image_url}");
+        let mut response = client.get(image_url).send()?;
 
         // Setup a temporary file
         let sysext_store = self.rootdir.join(DEFAULT_STORE);

--- a/lib/src/manager.rs
+++ b/lib/src/manager.rs
@@ -472,7 +472,7 @@ impl Manager {
                 }
             };
             let Ok(image) = Image::new(&config.Name, filename.clone().into(), Some(hash)) else {
-                error!("Invalid sysext name: {filename}");
+                warn!("Ignoring invalid sysext: {filename}");
                 continue;
             };
             remote_images.push(image);

--- a/lib/src/sysext.rs
+++ b/lib/src/sysext.rs
@@ -47,6 +47,13 @@ impl Image {
         };
         let mut filename = filename.to_string();
 
+        if !filename.starts_with(name) {
+            return Err(anyhow!(
+                "sysext image name must start with its own name: {}",
+                filename
+            ));
+        }
+
         if !filename.ends_with(".raw") {
             return Err(anyhow!(
                 "sysext image name must end with the `.raw` extension: {}",

--- a/sysexts-manager/usr/lib/sysexts-manager/sysexts-manager.conf
+++ b/sysexts-manager/usr/lib/sysexts-manager/sysexts-manager.conf
@@ -1,3 +1,3 @@
 Name = "sysexts-manager"
 Kind = "latest"
-Url = "https://github.com/travier/sysexts-manager/releases/download/sysexts-manager/"
+Url = "https://github.com/travier/sysexts-manager/releases/download"

--- a/test-data/basic-test.sh
+++ b/test-data/basic-test.sh
@@ -19,9 +19,9 @@ sudo rm -rf /etc/sysexts-manager/*.conf
 "${cmd[@]}" status
 systemd-sysext status
 
-sudo "${cmd[@]}" add tree https://extensions.fcos.fr/extensions/tree
-sudo "${cmd[@]}" add htop https://extensions.fcos.fr/extensions/htop
-sudo "${cmd[@]}" add gdb  https://extensions.fcos.fr/extensions/gdb
+sudo "${cmd[@]}" add tree https://extensions.fcos.fr/extensions
+sudo "${cmd[@]}" add htop https://extensions.fcos.fr/extensions
+sudo "${cmd[@]}" add gdb  https://extensions.fcos.fr/extensions
 test -f /etc/sysexts-manager/tree.conf
 test -f /etc/sysexts-manager/htop.conf
 test -f /etc/sysexts-manager/gdb.conf


### PR DESCRIPTION
Minor cleanups

---

Ignore sysexts images in SHA256SUM with non matching name

This is not exhautive as `foo-bar` would still be accepted for a `foo`
sysext.

---

Remove sysext name from URL and document expectations

---

test-data/basic-test: Improve test output

---

justfile: Add lint recipe

---

README: Bump version